### PR TITLE
Provide support for custom auth user model

### DIFF
--- a/tabular_permissions/admin.py
+++ b/tabular_permissions/admin.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin, User, Group, GroupAdmin
+from django.contrib.auth.admin import UserAdmin, Group, GroupAdmin
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from tabular_permissions.widgets import TabularPermissionsWidget
 from . import app_settings
+
+User = get_user_model()
 
 
 class UserTabularPermissionsAdminBase(object):


### PR DESCRIPTION
Enable support for projects which uses Django custom auth user model instead of the default one - https://docs.djangoproject.com/en/1.10/topics/auth/customizing/#substituting-a-custom-user-model

I've seen that tests already uses this pattern, but the codebase does not - https://github.com/RamezIssac/django-tabular-permissions/blob/master/tests/test_tabular_permissions/tests.py#L10

Without this change following error is raised during project bootstrap:

`django.core.exceptions.ImproperlyConfigured: Please make sure that django.contrib.auth comes before tabular_permissions in INSTALLED_APPS`
