### PR TITLE
fix: Submit event handler in FilteredSelectMultiple removes selected …

### DIFF
--- a/tabular_permissions/static/tabular_permissions/tabular_permissions.js
+++ b/tabular_permissions/static/tabular_permissions/tabular_permissions.js
@@ -31,7 +31,8 @@ window.onload = function() {
                 $(elem).prop('checked', $this.prop('checked'));
             })
         });
-        $('form').on('submit', function () {
+        setTimeout(
+            () => $('form').on('submit', function () {
             var user_perms = [];
             var table_permissions = $('#tabular_permissions');
             var input_name = table_permissions.attr('data-input-name');
@@ -47,6 +48,9 @@ window.onload = function() {
                 output.push('<option value="' + value + '" selected="selected" style="display:none"></option>');
             });
             user_group_permissions.append(output);
-        })
+        }),
+            0
+        )
+
     })(django.jQuery);
 };


### PR DESCRIPTION
…options from tabular_permissions

https://github.com/RamezIssac/django-tabular-permissions/issues/27

If reminder_perms exists, tabular_permissions uses FilteredSelectMultiple. Standard order on submit:
- tabular_permissions adds selected options with perms
- FilteredSelectMultiple cleans options, leaving only those in its cache <= we lose custom perm options
- send form to server

This fix changes order to:
- FilteredSelectMultiple cleans options, leaving only those in its cache
- tabular_permissions adds custom perm options
- send form to server