### PR TITLE
Fix error caused by non-existent `model.label`

### DIFF
--- a/tabular_permissions/widgets.py
+++ b/tabular_permissions/widgets.py
@@ -109,6 +109,7 @@ class TabularPermissionsWidget(FilteredSelectMultiple):
                     app_dict['models'][model_name] = {
                         'model_name': model_name,
                         'model': model,
+                        'label': force_str(model._meta.label_lower.replace('.', '_')),
                         'verbose_name_plural': force_str(model._meta.verbose_name_plural),
                         'verbose_name': force_str(model._meta.verbose_name),
                         'view_perm_id': view_perm_id,


### PR DESCRIPTION
I've submitted this PR to resolve the issue of duplicate IDs found in forms, for reference [here the related issue](https://github.com/RamezIssac/django-tabular-permissions/issues/26)

For further details, the following is a screenshot of the error:
![image](https://github.com/RamezIssac/django-tabular-permissions/assets/101522391/747f131d-ad75-4f36-8631-d5f571657f14)

Although the duplication does not affect the project's operational functionality, removing these errors will enhance the overall  cleanliness and reduce unnecessary error in a production environment.